### PR TITLE
feat: only show first line in commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All data is stored in Github, there is no additional persistent store/database r
 Start the two services in development/hot reload mode. Respectively:
 
 - `web` with `cd web && npm install && npm run dev`
-- `api` with `cd api && cargo watch -x 'run -- --bind 0.0.0.0:3000`
+- `api` with `cd api && cargo watch -x 'run -- --bind 0.0.0.0:3000'`
 
 ## Standalone deployment
 

--- a/qvet-web/src/components/CommitRow.tsx
+++ b/qvet-web/src/components/CommitRow.tsx
@@ -34,7 +34,7 @@ export default function CommitRow({ commit }: { commit: Commit }) {
           maxWidth: "500px",
         }}
       >
-        {commit.commit.message}
+        {commit.commit.message.split("\n")[0]}
       </TableCell>
       <TableCell>
         {commit.author ? <UserLink user={commit.author} /> : <i>unknown</i>}


### PR DESCRIPTION
Discovered this as I've started writing more complex commit messages
recently, but the commit message was just being shoved into the table
with the assumption that there won't be any body to the commit.

This patch updates the way that a commit message is displayed by
splitting on new lines and taking the first;

	const a = "this is a test\n\nthis is another test";
	console.log(a.split("\n")[0]); // "this is a test"

This also works for commit messages that don't have any new lines in
them;

	const b = "this is a test";
	console.log(b.split("\n")[0]); // "this is a test

---

Unfortunately I don't have any way of verifying 100% that this works (other than testing with different strings) due to not getting the verification working. But hopefully @tommilligan you'll be able to walk me through that briefly.

---

This also has a commit for a minor `README.md` typo that I saw.