### PR TITLE
feat: automatically match system theme

### DIFF
--- a/qvet-web/src/components/Theme.tsx
+++ b/qvet-web/src/components/Theme.tsx
@@ -7,9 +7,11 @@ export const ColorModeContext = React.createContext({
 
 type ThemeMode = "light" | "dark";
 
+const systemIsDarkTheme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+
 export default function Theme({ children }: { children: React.ReactNode }) {
   const storedMode = (localStorage.getItem("theme_mode") ??
-    "light") as ThemeMode;
+    systemIsDarkTheme ?  "dark" : "light") as ThemeMode;
   const [mode, setMode] = React.useState<ThemeMode>(storedMode);
   const colorMode = React.useMemo(
     () => ({


### PR DESCRIPTION
This commit adds a small piece of logic to check whether the user has specified Dark mode in their system theme, and sets the default value of the theme accordingly.

We're using `matchMedia` which should be supported by all major browsers so there shouldn't be any compatibility problem, but we do a quick check for it and fallback to Light mode just in case.

	https://caniuse.com/?search=matchmedia

For the CSS selector itself, it's only IE that doesn't seem to support it but I think that's fine

	https://caniuse.com/?search=prefers-color-scheme