### PR TITLE
feat: add support for .env file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1061,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "clap",
+ "dotenv",
  "env_logger",
  "hex",
  "http",

--- a/qvet-api/Cargo.toml
+++ b/qvet-api/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = "0.3.16"
 tracing = "0.1.37"
 http = "0.2.8"
 axum-extra = { version = "0.5.0", features = ["cookie", "cookie-private"] }
+dotenv = "0.15.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/qvet-api/src/runtime.rs
+++ b/qvet-api/src/runtime.rs
@@ -2,6 +2,7 @@ use crate::redacted::Redacted;
 use anyhow::{anyhow, Context, Result};
 use axum_extra::extract::cookie::Key;
 use clap::Parser;
+use dotenv::dotenv;
 use oauth2::basic::BasicClient;
 use std::net::SocketAddr;
 
@@ -25,6 +26,8 @@ pub struct State {
 }
 
 pub fn github_credentials_from_env() -> Result<(String, String)> {
+    dotenv().ok();
+
     Ok((
         std::env::var("GITHUB_CLIENT_ID").context("github client id")?,
         std::env::var("GITHUB_CLIENT_SECRET").context("github client secret")?,


### PR DESCRIPTION
Add the `dotenv` package so the API can load environment variables from a
`.env` file as well as arguemnts passed to the API start command.