### PR TITLE
feat(ui): allow mutliple links on deploy message

### DIFF
--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -232,7 +232,7 @@ export default function DeploymentHeadline({
     : null;
 
   const config = useConfig();
-  const action = !!config.data && config.data.action.ready;
+  const actions = config.data?.action.ready ?? [];
 
   const checkRuns = useCheckRuns(config.data?.check_runs.enabled || false);
   const unresolvedCheckRuns = checkRuns.isSuccess
@@ -318,7 +318,15 @@ export default function DeploymentHeadline({
       <Alert
         key="ready-to-deploy"
         severity="success"
-        action={action ? <ReadyAction action={action} /> : null}>
+        action={
+          actions.length > 0 ? (
+            <Stack direction="row" spacing={1}>
+              {actions.map((action: Action) => (
+                <ReadyAction key={action.name} action={action} />
+              ))}
+            </Stack>
+          ) : null
+        }>
         Ready to Deploy
         <DeploymentUsers commits={commits} />
       </Alert>,

--- a/qvet-web/src/utils/config.ts
+++ b/qvet-web/src/utils/config.ts
@@ -51,7 +51,17 @@ const SCHEMA_ACTION = {
 const SCHEMA_ACTION_LOOKUP = {
   type: "object",
   properties: {
-    ready: SCHEMA_ACTION,
+    ready: {
+      oneOf: [
+        SCHEMA_ACTION, // Single action (backward compatible)
+        {
+          type: "array",
+          items: SCHEMA_ACTION,
+          minItems: 1,
+          maxItems: 5, // Reasonable UI limit
+        },
+      ],
+    },
   },
   required: [],
   additionalProperties: false,
@@ -157,7 +167,7 @@ const SCHEMA = {
 
 export interface Config {
   action: {
-    ready: Action | null;
+    ready: Array<Action>;
   };
   commit: {
     ignore: {
@@ -232,7 +242,11 @@ export function parseConfigFile(configFile: string): ParseConfigFileResult {
 function standardiseConfig(raw: any): Config {
   return {
     action: {
-      ready: raw.action?.ready ?? null,
+      ready: Array.isArray(raw.action?.ready)
+        ? raw.action.ready
+        : raw.action?.ready
+        ? [raw.action.ready]
+        : [],
     },
     commit: {
       ignore: {


### PR DESCRIPTION
Allow 1 or more links to be added to the ready to deploy message on qvet